### PR TITLE
Update Apostrophe for RGBA theme colors

### DIFF
--- a/pak.json
+++ b/pak.json
@@ -1,12 +1,13 @@
 {
   "name": "ScrapeGoat",
-  "version": "v2.1.0",
+  "version": "v2.2.0",
   "type": "TOOL",
   "description": "Scrape artwork and manuals from ScreenScraper.fr and download cheats from Libretro for your ROM library.",
   "author": "Helaas",
   "repo_url": "https://github.com/Helaas/nextui-scrapegoat-pak",
   "release_filename": "ScrapeGoat.pakz",
   "changelog": {
+    "v2.2.0": "Fixes incorrect colors with NextUI's RGBA theme format.",
     "v2.1.0": "Adds PDF manual downloads with configurable storage, background queue handoff and resume, clearer quit behavior, smarter cheat-file selection, and daemon-safe artwork scraping.",
     "v2.0.0": "New Apostrophe UI with queue/progress tracking, existing-file overviews, Miyoo Flip (my355) support, and can now scrape Sega Saturn.",
     "v1.0.2": "Bugfix for certain consoles being incorrectly mapped.",


### PR DESCRIPTION
## Summary

Update the Apostrophe dependency to `aa84f9d`, which adds compatibility with NextUI's current theme color format.

NextUI now emits theme colors as `RRGGBBAA`. The previous Apostrophe parser treated eight-digit values as a packed integer and decoded the low 24 bits, shifting the color channels. The updated parser keeps legacy `RRGGBB` colors working while decoding `RRGGBBAA` correctly and preserving alpha.

## Validation

- Built a fresh package with `make package`
- Verified ZIP integrity and package layout
- Confirmed the binaries archived in the package match the freshly built platform binaries
- Staged the package on Brick and Smart Pro S and verified matching SHA-256 checksums
- Requester confirmed successful on-device verification

## Release

- Bump `pak.json` to `v2.2.0`.
- Changelog: Fixes incorrect colors with NextUI's RGBA theme format.
